### PR TITLE
Cop for collect methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Novu shared rubocop configuration.
 
+## Updating Cops
+
+Open a pull request with the proposed changes and ask for reviews in other teams.
+Remember that cops are ordered alphabetically in `default.yml` and avoid adding paths that only make sense for a particular repository.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/default.yml
+++ b/default.yml
@@ -17,6 +17,15 @@ AllCops:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
+Lint/AmbiguousBlockAssociation:
+    Exclude:
+    - spec/**/*
+
+Metrics/BlockLength:
+  Exclude:
+  - config/routes.rb
+  - app/views/api/**/*
+
 Metrics/LineLength:
   Max: 110
   # To make it possible to copy or click on URIs in the code, we allow lines
@@ -28,24 +37,26 @@ Metrics/LineLength:
   Exclude:
     - config/routes.rb # Annotations run long.
 
-Metrics/BlockLength:
-  Exclude:
-  - config/routes.rb
-  - app/views/api/**/*
-
-NumericLiterals:
+Naming/FileName:
   Enabled: false
 
 Rails/HasAndBelongsToMany:
   Enabled: false
 
+Rails/SkipsModelValidations:
+  Exclude:
+    - spec/**/*
+
+Style/CollectionMethods:
+  Enabled: true
+
 Style/Documentation:
   Enabled: false
 
-Naming/FileName:
+Style/FrozenStringLiteralComment:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
+Style/NumericLiterals:
   Enabled: false
 
 Style/PercentLiteralDelimiters:
@@ -57,11 +68,3 @@ Style/PercentLiteralDelimiters:
 
 Style/RegexpLiteral:
   Enabled: false
-
-Rails/SkipsModelValidations:
-  Exclude:
-    - spec/**/*
-
-Lint/AmbiguousBlockAssociation:
-    Exclude:
-    - spec/**/*


### PR DESCRIPTION
@goronfreeman pointed out that is better to have just a single method name instead using "collect" and"map", "inject" and "reduce", "detect" and"find", "find_all" and "select".

More info: 
https://rubocop.readthedocs.io/en/latest/cops_style/#stylecollectionmethods
https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size