### PR TITLE
NOVU-25996: Bump metric cops by 50%

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,4 @@
-Rails:
-  Enabled: true
-
+# Common configuration.
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
@@ -14,41 +12,12 @@ AllCops:
     - script/**/*
     - vendor/**/*
 
+#################### Layout ################################
+
 Layout/DotPosition:
   EnforcedStyle: trailing
 
-Lint/AmbiguousBlockAssociation:
-    Exclude:
-    - spec/**/*
-
-Metrics/BlockLength:
-  Exclude:
-  - config/routes.rb
-  - app/views/api/**/*
-
-Metrics/LineLength:
-  Max: 110
-  # To make it possible to copy or click on URIs in the code, we allow lines
-  # contaning a URI to be longer than Max.
-  AllowURI: true
-  URISchemes:
-    - http
-    - https
-  Exclude:
-    - config/routes.rb # Annotations run long.
-
-Naming/FileName:
-  Enabled: false
-
-Rails/HasAndBelongsToMany:
-  Enabled: false
-
-Rails/SkipsModelValidations:
-  Exclude:
-    - spec/**/*
-
-Style/CollectionMethods:
-  Enabled: true
+#################### Style #################################
 
 Style/Documentation:
   Enabled: false
@@ -68,3 +37,59 @@ Style/PercentLiteralDelimiters:
 
 Style/RegexpLiteral:
   Enabled: false
+
+#################### Naming ################################
+
+Naming/FileName:
+  Enabled: false
+
+#################### Metrics ###############################
+
+Metrics/AbcSize:
+  Max: 22.5
+
+Metrics/BlockLength:
+  Exclude:
+  - config/routes.rb
+  - app/views/api/**/*
+
+Metrics/ClassLength:
+  Max: 150
+
+Metrics/CyclomaticComplexity:
+  Max: 9
+
+Metrics/LineLength:
+  Max: 110
+  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
+  # directives like '# rubocop: enable ...' when calculating a line's length.
+  IgnoreCopDirectives: true
+  Exclude:
+    - config/routes.rb # Annotations run long.
+
+Metrics/MethodLength:
+  Max: 15
+
+Metrics/ModuleLength:
+  Max: 150
+
+Metrics/PerceivedComplexity:
+  Max: 10
+
+#################### Lint ##################################
+
+Lint/AmbiguousBlockAssociation:
+    Exclude:
+    - spec/**/*
+
+#################### Rails #################################
+
+Rails:
+  Enabled: true
+
+Rails/HasAndBelongsToMany:
+  Enabled: false
+
+Rails/SkipsModelValidations:
+  Exclude:
+    - spec/**/*

--- a/default.yml
+++ b/default.yml
@@ -19,6 +19,9 @@ Layout/DotPosition:
 
 #################### Style #################################
 
+Style/CollectionMethods:
+  Enabled: true
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
This bumps all the metric cops that have been annoying many of the developers by 50%. The line length cop was left as-is. Here are the cops that were adjusted, as I also made some formatting changes to match the default Rubocop config:

- Metrics/AbcSize
- Metrics/ClassLength
- Metrics/CyclomaticComplexity
- Metrics/MethodLength
- Metrics/ModuleLength
- Metrics/PerceivedComplexity

The Metrics/BlockLength cop was also not touched, as I don't remember seeing this myself or hearing anyone complain about it. It is set to 25 by default.

https://mynovu.atlassian.net/browse/NOVU-25996
@novu/purple 
@novu/developers 