### PR TITLE
Update Rubocop to latest version

### DIFF
--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.3.2'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.52.1'
+  spec.add_dependency 'rubocop', '~> 0.63.1'
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
After the new gem version gets published, the following repos will have updates also:
- Titan
- Hermes
- Iris
- Odyssey