### PR TITLE
Don't exclude db/ for all cops

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -7,7 +7,6 @@ AllCops:
     - bin/**/*
     - client/**/*
     - config/boot.rb
-    - db/**/*
     - rgloader/loader.rb
     - script/**/*
     - vendor/**/*
@@ -50,11 +49,14 @@ Naming/FileName:
 
 Metrics/AbcSize:
   Max: 22.5
+  Exclude:
+    - db/**/*
 
 Metrics/BlockLength:
   Exclude:
   - config/routes.rb
   - app/views/api/**/*
+  - db/**/*
 
 Metrics/ClassLength:
   Max: 150
@@ -69,9 +71,12 @@ Metrics/LineLength:
   IgnoreCopDirectives: true
   Exclude:
     - config/routes.rb # Annotations run long.
+    - db/**/*
 
 Metrics/MethodLength:
   Max: 15
+  Exclude:
+    - db/**/*
 
 Metrics/ModuleLength:
   Max: 150


### PR DESCRIPTION
For some reason the `db/` directory was explicitly excluded from linting. The main reason I am enabling this is for the use of [outrigger](https://github.com/instructure/outrigger) in Hermes. The gem is supposed to give a linting error if a predeploy or postdeploy tag isn't specified in a migration. This is part of an effort that me and Andrew Yost are working on for handling migrations better in production.

This also has the side effect of re-enabling a bunch of potentially useful cops that are specific to migrations, like warning when something is non-reversible. I disabled the metric cops that may be annoying while writing migrations, so I think the rest of them should be just fine.

@novu/purple 
@arich 