### PR TITLE
Update rubocop to 0.69.0 and gem version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ $ bundle install
 Create a `.rubocop.yml` in the repository with the following configuration:
 
 ```yaml
-inherit_from:
-  - https://raw.githubusercontent.com/novu/ruby-novu-code-style/master/default.yml
+inherit_gem:
+  novu-style:
+    - default.yml
 ```
 
 Now, run:

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.63.1'
+  spec.add_dependency 'rubocop', '~> 0.69.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Upgrade to latest rubocop, also changed the inherit from to use the gem as is more robust, in the past we had to reference the default.yml URL due to constraints in Solano which is no longer a problem in CircleCI.

Review: @goronfreeman @arich 