### PR TITLE
Update line length cop limit to 120

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -65,7 +65,7 @@ Metrics/CyclomaticComplexity:
   Max: 9
 
 Metrics/LineLength:
-  Max: 110
+  Max: 120
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
   IgnoreCopDirectives: true

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.5.0'.freeze
+    VERSION = '0.5.1'.freeze
   end
 end


### PR DESCRIPTION
@novu/developers @goronfreeman @sebabeceiro 
This is a proposal, plain and simple. I've seen some chatter about appeasing rubocop lately on PRs, and a lot of ` # rubocop:disable Metrics/LineLength` used. 

Can we agree to bump the line length limit to 120 characters?