### PR TITLE
Allow migrations to skip model validations and reference ActiveRecord::Base

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -101,3 +101,8 @@ Rails/HasAndBelongsToMany:
 Rails/SkipsModelValidations:
   Exclude:
     - spec/**/*
+    - db/**/*
+
+ Rails/ApplicationRecord:
+  Exclude:
+    - db/**/*

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.5.1'.freeze
+    VERSION = '0.5.2'.freeze
   end
 end


### PR DESCRIPTION
From https://github.com/novu/nyx/pull/49/files#diff-11a0d7906801d9dea0eccb85667ad811R40
Since migrations often do not want to fail because of potentially bad data not related to the migration at hand, we should be able to skip validations freely in migrations. 

Also in the `good_migrations` gem, `ApplicationRecord` is not allowed to be referenced because it lives in the `/app` dir. I think it makes sense to disable the rule requiring using `ApplicationRecord` over `ActiveRecord::Base` for the purposes of defining new shell models in migrations. 

Thoughts? @goronfreeman @sebabeceiro @novu/developers 