### PR TITLE
Include rails cops that have been moved to the rubocop-rails gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ You do not need to include rubocop directly in your application's dependences. N
 
 ## Changelog
 
+#### 0.5.4
+
+  - Include rails cops that have been moved to the rubocop-rails gem
+
+
 #### 0.5.3
 
   - Update rubocop to 0.75.0

--- a/default.yml
+++ b/default.yml
@@ -1,3 +1,5 @@
+require: rubocop-rails
+
 # Common configuration.
 AllCops:
   TargetRubyVersion: 2.3

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.5.3'.freeze
+    VERSION = '0.5.4'.freeze
   end
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 0.75.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.3.2'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Description: Last commit on this repo removed checks for rails cops since they were moved to a different gem (rubocop-rails)
Review: @novu/developers 