### PR TITLE
Update rubocop to 0.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update rubocop to 0.82.x.
 - Update rubocop-rails to 2.5.x
 - Default ruby version to 2.6
+- Remove CodeClimate documentation
 
 ## [0.5.6] - 2019-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2020-04-21
+
+### Changed
+
+- Update rubocop to 0.82.x.
+- Update rubocop-rails to 2.5.x
+- Default ruby version to 2.6
+
 ## [0.5.6] - 2019-12-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -45,19 +45,6 @@ Now, run:
 $ bundle exec rubocop
 ```
 
-## Code Climate setup
-
-For repositories that are tracked in Code Climate, add the following at the top of `.codeclimate.yml`:
-
-```yaml
-prepare:
-  fetch:
-  - url: 'https://raw.githubusercontent.com/novu/ruby-novu-code-style/master/default.yml'
-    path: '.rubocop-https---raw-githubusercontent-com-novu-ruby-novu-code-style-master-default-yml'
-```
-
->NOTE: Any local rules in .rubocop.yml will take precedence over inheriting from a local project file, which will take precedence over inheriting from a gem.
-
 You do not need to include rubocop directly in your application's dependences. Novu-style will include a specific version of `rubocop` that is shared across all projects.
 
 ## Changelog

--- a/default.yml
+++ b/default.yml
@@ -2,7 +2,8 @@ require: rubocop-rails
 
 # Common configuration.
 AllCops:
-  TargetRubyVersion: 2.3
+  NewCops: enable
+  TargetRubyVersion: 2.6
   Exclude:
     - !ruby/regexp /.*solano.*\.rb$/
     - !ruby/regexp /.*tddium.*\.rb$/

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.5.6'.freeze
+    VERSION = '0.5.7'.freeze
   end
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.78.0'
-  spec.add_dependency 'rubocop-rails', '~> 2.4.0'
+  spec.add_dependency 'rubocop', '~> 0.82.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.5.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Given that we are moving from CodeClimate we might need to get the latest rubocop version.
Review: @novu/developers 