### PR TITLE
NOVU-34851 Upgrade rubocop and rubocop-rails versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.8] - 2020-12-01
+
+### Changed
+
+- Update rubocop to 0.93.0.
+- Update rubocop-rails to 2.8.1
+
 ## [0.5.7] - 2020-04-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update rubocop to 0.93.0.
+- Update rubocop to 1.4.2
 - Update rubocop-rails to 2.8.1
 
 ## [0.5.7] - 2020-04-21

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.5.7'.freeze
+    VERSION = '0.5.8'.freeze
   end
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.82.0'
-  spec.add_dependency 'rubocop-rails', '~> 2.5.0'
+  spec.add_dependency 'rubocop', '~> 0.93.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.8.1'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.93.0'
+  spec.add_dependency 'rubocop', '~> 1.4.2'
   spec.add_dependency 'rubocop-rails', '~> 2.8.1'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
## 🗒️ Description

New versions of rubocop and rubocop rails are available. This change will add those versions to this shared gem.

## 🎫 Story

[NOVU-34851](https://mynovu.atlassian.net/browse/NOVU-34851)

## :mega: Mentions

@novu/brown