### PR TITLE
Update rubocop and add extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2021-04-22
+
+### Changed
+
+- Update rubocop to 1.13.0
+- Update rubocop-rails to 2.9.1
+- Experimentally add rubocop-rspec and rubocop-rake
+
 ## [0.5.8] - 2020-12-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ inherit_gem:
     - default.yml
 ```
 
+Additionally you can add new extensions `rubocop-rspec` and `rubocop-rake` to your project in the local `rubocop.yml` file
+
 Now, run:
 
 ```bash

--- a/default.yml
+++ b/default.yml
@@ -93,6 +93,9 @@ Lint/AmbiguousBlockAssociation:
     Exclude:
     - spec/**/*
 
+Lint/SymbolConversion:
+  EnforcedStyle: consistent
+
 #################### Rails #################################
 
 Rails:

--- a/lib/novu/style/version.rb
+++ b/lib/novu/style/version.rb
@@ -1,5 +1,5 @@
 module Novu
   module Style
-    VERSION = '0.5.8'.freeze
+    VERSION = '0.6.0'.freeze
   end
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -29,6 +29,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 1.13.0'
   spec.add_dependency 'rubocop-rails', '~> 2.9.1'
+
+  spec.add_dependency 'rubocop-rake', '~> 0.5.1'
+  spec.add_dependency 'rubocop-rspec', '~> 2.2.0'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/novu-style.gemspec
+++ b/novu-style.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 1.4.2'
-  spec.add_dependency 'rubocop-rails', '~> 2.8.1'
+  spec.add_dependency 'rubocop', '~> 1.13.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.9.1'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
**Description:** Update to latest versions of rubocop and rubocop-rails, also add extensions rubocop-rspec and rubocop-rake but do not enforce them, leave that as an options for each repository.

Review: @novu/developers 